### PR TITLE
Changing how password is added to process string, to avoid some passwords breaking the shell

### DIFF
--- a/tasks/db_dump.js
+++ b/tasks/db_dump.js
@@ -77,7 +77,7 @@ module.exports = function(grunt) {
         var tpl_mysqldump = grunt.template.process(commandTemplates.mysqldump, {
             data: {
                 user: options.user,
-                pass: options.pass != "" ? '-p' + options.pass : '',  
+                pass: options.pass !== "" ? '--password="' + options.pass + '"' : '',
                 database: options.database,
                 host: options.host,
 	            port: options.port


### PR DESCRIPTION
I hit this problem with a particularly crazy password from a password generator. The particular password ended up hanging grunt.

I am sure with this change there are still valid MySQL passwords that will break things.
