### PR TITLE
Changing reference to <%= target %> in README.md description of backup_to option to something that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Description: ssh connection string in the format `SSH_USER@SSH_HOST`. The task a
 
 #### backup_to
 Type: `String`
-Default: `"db/backups/<%= grunt.template.today('yyyy-mm-dd') %> - <%= target %>.sql"`
-Description: full destination file path of the generated dump. This option can include templates such as `<%= grunt.template.today('yyyy-mm-dd') %>` or `<%= target %>`.
+Default: `"db/backups/<%= grunt.template.today('yyyy-mm-dd') %> - <%= grunt.task.current.target %>.sql"`
+Description: full destination file path of the generated dump. This option can include templates such as `<%= grunt.template.today('yyyy-mm-dd') %>` or `<%= grunt.task.current.target %>`.
 
 ### Options
 


### PR DESCRIPTION
The current description for the backup_to option gives the example of using <%= target %>, however this will throw an error as the target variable won't exist in the context of the current task.

I have changed it to <%= grunt.task.current.target %> which is the [documented way](http://gruntjs.com/inside-tasks#this.target) of accessing this value.
