### PR TITLE
Add —hex-blob to the mysqldump call

### DIFF
--- a/tasks/db_dump.js
+++ b/tasks/db_dump.js
@@ -18,7 +18,7 @@ var shell = require('shelljs'),
  * https://github.com/gruntjs/grunt/wiki/grunt.template
  */
 var commandTemplates = {
-	mysqldump: "mysqldump -h <%= host %> -P <%= port %> -u<%= user %> <%= pass %> <%= database %>",
+	mysqldump: "mysqldump --hex-blob -h <%= host %> -P <%= port %> -u<%= user %> <%= pass %> <%= database %>",
 	ssh: "ssh <%= host %>"
 };
 


### PR DESCRIPTION
Exporting binary fields as hex prevents import issues
