### PR TITLE
Use mysqldump's --result-file argument instead of piping output from stdout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,8 +34,8 @@ module.exports = function(grunt) {
     db_dump: {
 	    // This one should work
         mysql: '<%= db_fixture.mysql %>',
-	    // This one should fail 
-        info_schema: '<%= db_fixture.info_schema %>'	    
+	    // This one should fail
+        info_schema: '<%= db_fixture.info_schema %>'
     },
 
     // Unit tests.
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'deployments', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'db_dump', 'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "shelljs": "~0.1.4"
+    "shelljs": "~0.6.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1"
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt": "~0.4.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.5"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/db_dump.js
+++ b/tasks/db_dump.js
@@ -18,7 +18,7 @@ var shell = require('shelljs'),
  * https://github.com/gruntjs/grunt/wiki/grunt.template
  */
 var commandTemplates = {
-  mysqldump: "MYSQL_PWD=<%= pass %> mysqldump --hex-blob -h <%= host %> -P <%= port %> -u<%= user %> <%= database %> <%=extra_args%>",
+  mysqldump: "MYSQL_PWD=<%= pass %> mysqldump --hex-blob -h <%= host %> -P <%= port %> -u<%= user %> <%= database %> -r <%= target %> <%=extra_args%>",
   ssh: "ssh <%= host %>"
 };
 
@@ -82,6 +82,7 @@ module.exports = function (grunt) {
         database: options.database,
         host: options.host,
         port: options.port,
+        target: paths.file,
         extra_args: options.extra_args
       }
     });
@@ -101,18 +102,15 @@ module.exports = function (grunt) {
       cmd = tpl_ssh + " \\ " + tpl_mysqldump;
     }
 
-    // Capture output...
+    // Execute command...
     var ret = shell.exec(cmd, {
       silent: true
     });
 
     if (ret.code != 0) {
-      grunt.log.error(ret.output)
+      grunt.log.error(ret.stdout + ret.stderr)
       return false;
     }
-
-    // Write output to file using native Grunt methods
-    grunt.file.write(paths.file, ret.output);
 
     return true;
   }

--- a/tasks/db_dump.js
+++ b/tasks/db_dump.js
@@ -18,7 +18,7 @@ var shell = require('shelljs'),
  * https://github.com/gruntjs/grunt/wiki/grunt.template
  */
 var commandTemplates = {
-  mysqldump: "MYSQL_PWD=<%= pass %> mysqldump --hex-blob -h <%= host %> -P <%= port %> -u<%= user %> <%= database %> -r <%= target %> <%=extra_args%>",
+  mysqldump: "MYSQL_PWD='<%= pass %>' mysqldump --hex-blob -h <%= host %> -P <%= port %> -u<%= user %> <%= database %> -r <%= target %> <%=extra_args%>",
   ssh: "ssh <%= host %>"
 };
 


### PR DESCRIPTION
Hi!

When making backups of some large databases it is possible to run into memory problems because the code stores the output of mysqldump in memory before writing it to the output file. This patch changes it to tell mysqldump to write the output to file directly, so that nothing has to be stored in memory. It has the advantage of speeding things up quite a bit as well.

The password sent to mysql is also quoted - otherwise the command fails if the password has spaces in it (bug introduced by 9021a941).

I've also updated various requirements and fiddled with the test task so that it runs.
